### PR TITLE
Use the new SolidFire driver name

### DIFF
--- a/manifests/backend/solidfire.pp
+++ b/manifests/backend/solidfire.pp
@@ -11,7 +11,7 @@
 #
 # [*volume_driver*]
 #   (optional) Setup cinder-volume to use SolidFire volume driver.
-#   Defaults to 'cinder.volume.drivers.solidfire.SolidFire'
+#   Defaults to 'cinder.volume.drivers.solidfire.SolidFireDriver'
 #
 # [*san_ip*]
 #   (required) IP address of SolidFire clusters MVIP.
@@ -43,7 +43,7 @@ define cinder::backend::solidfire(
   $san_login,
   $san_password,
   $volume_backend_name = $name,
-  $volume_driver       = 'cinder.volume.drivers.solidfire.SolidFire',
+  $volume_driver       = 'cinder.volume.drivers.solidfire.SolidFireDriver',
   $sf_emulate_512      = true,
   $sf_allow_tenant_qos = false,
   $sf_account_prefix   = '',

--- a/manifests/volume/solidfire.pp
+++ b/manifests/volume/solidfire.pp
@@ -7,7 +7,7 @@
 #
 # [*volume_driver*]
 #   (optional) Setup cinder-volume to use SolidFire volume driver.
-#   Defaults to 'cinder.volume.drivers.solidfire.SolidFire'
+#   Defaults to 'cinder.volume.drivers.solidfire.SolidFireDriver'
 #
 # [*san_ip*]
 #   (required) IP address of SolidFire clusters MVIP.
@@ -38,7 +38,7 @@ class cinder::volume::solidfire(
   $san_ip,
   $san_login,
   $san_password,
-  $volume_driver       = 'cinder.volume.drivers.solidfire.SolidFire',
+  $volume_driver       = 'cinder.volume.drivers.solidfire.SolidFireDriver',
   $sf_emulate_512      = true,
   $sf_allow_tenant_qos = false,
   $sf_account_prefix   = '',

--- a/spec/classes/cinder_volume_solidfire_spec.rb
+++ b/spec/classes/cinder_volume_solidfire_spec.rb
@@ -15,7 +15,7 @@ describe 'cinder::volume::solidfire' do
 
   describe 'solidfire volume driver' do
     it 'configure solidfire volume driver' do
-      should contain_cinder_config('DEFAULT/volume_driver').with_value('cinder.volume.drivers.solidfire.SolidFire')
+      should contain_cinder_config('DEFAULT/volume_driver').with_value('cinder.volume.drivers.solidfire.SolidFireDriver')
       should contain_cinder_config('DEFAULT/san_ip').with_value('127.0.0.2')
       should contain_cinder_config('DEFAULT/san_login').with_value('solidfire')
       should contain_cinder_config('DEFAULT/san_password').with_value('password')

--- a/spec/defines/cinder_backend_solidfire_spec.rb
+++ b/spec/defines/cinder_backend_solidfire_spec.rb
@@ -18,7 +18,7 @@ describe 'cinder::backend::solidfire' do
   describe 'solidfire volume driver' do
     it 'configure solidfire volume driver' do
       should contain_cinder_config('solidfire/volume_driver').with_value(
-        'cinder.volume.drivers.solidfire.SolidFire')
+        'cinder.volume.drivers.solidfire.SolidFireDriver')
       should contain_cinder_config('solidfire/san_ip').with_value(
         '127.0.0.2')
       should contain_cinder_config('solidfire/san_login').with_value(


### PR DESCRIPTION
The driver name for the SolidFire driver switched back in July of 2013:

https://github.com/openstack/cinder/commit/fd139faaf3d3fc96825bbaf3397a529e5762d92c

There was a mapping of the old driver name to the new driver name until
April 2014 which is when it was removed:

https://github.com/openstack/cinder/commit/64f71b3306f7652bee60245d62af090aaa572cf7

With the Juno release the old driver name (SolidFire) can't be used any
more and must be changed to the new one (SolidFireDriver).